### PR TITLE
Add oauth2 scopes to generated hapi server

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
@@ -139,8 +139,8 @@ class ServerRenderer @Inject constructor(
                         |          <${it.resource().fullUri.variables.map { "$it: requiredString" }.joinToString(separator = ",\n")}>
                         |        },
                         |        failAction,${it.auth()}
-                        |      }  
-                        |   }
+                        |      },
+                        |    }
                         |}
                     """.trimMargin()
                 }.joinToString(separator = ",\n")


### PR DESCRIPTION
# Summary

This PR adds the OAuth2 scopes defined for a RAML method to our generated hapi server. this then allows us to use a hapi authentication scheme that talks to our OAuth2 introspection api to retrieve the scopes of a given OAUth2 token (see also my prototype for such an authentication scheme: https://github.com/katmatt/hapi-oauth2-introspection).