### PR TITLE
add patch MethodType

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/client/files_producers/ClientFileProducer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/client/files_producers/ClientFileProducer.kt
@@ -27,6 +27,7 @@ export type MethodType =
   | "HEAD"
   | "POST"
   | "PUT"
+  | "PATCH"
   | "DELETE"
   | "CONNECT"
   | "OPTIONS"

--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerHelpers.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerHelpers.kt
@@ -27,6 +27,7 @@ export type MethodType =
   | "HEAD"
   | "POST"
   | "PUT"
+  | "PATCH"
   | "DELETE"
   | "CONNECT"
   | "OPTIONS"


### PR DESCRIPTION
We want to use the `patch` method inside our `import-storage-service` and are currently blocked by the generator. I took a quick look and found this. Please let me know if I missed something that we should add to make it work.