### PR TITLE
Fix codegen for import api

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
@@ -230,7 +230,7 @@ class ServerRenderer @Inject constructor(
         return when (this) {
             is VrapObjectType -> {
                 val joiType = this.toJoiVrapType()
-                "import { ${joiType.simpleClassName} } from '@joi/${joiType.`package`}'"
+                "import { ${joiType.simpleClassName} } from '${joiType.`package`}'"
             }
             is VrapArrayType -> {
                 return this.itemType.joiImportStatement()

--- a/tools/codegen-gradle-plugin/src/main/kotlin/io/vrap/rmf/codegen/plugin/RamlCodeGeneratorTask.kt
+++ b/tools/codegen-gradle-plugin/src/main/kotlin/io/vrap/rmf/codegen/plugin/RamlCodeGeneratorTask.kt
@@ -101,12 +101,12 @@ open class RamlCodeGeneratorTask : DefaultTask() {
                 GeneratorComponent(generatorModule, JoiModule)
             }
             TargetType.TS_CLIENT_COMPLETE -> {
-                val generatorModule = GeneratorModule(apiProvider, generatorConfig, JoiBaseTypes)
+                val generatorModule = GeneratorModule(apiProvider, generatorConfig, TypeScriptBaseTypes)
                 GeneratorComponent(generatorModule, TypescriptModelModule, TypescriptClientModule)
             }
             TargetType.TS_SERVER_COMPLETE -> {
-                val generatorModule = GeneratorModule(apiProvider, generatorConfig, JoiBaseTypes)
-                GeneratorComponent(generatorModule, TypescriptModelModule,JoiModule, TypescriptServerModule)
+                val generatorModule = GeneratorModule(apiProvider, generatorConfig, TypeScriptBaseTypes)
+                GeneratorComponent(generatorModule, TypescriptModelModule, JoiModule, TypescriptServerModule)
             }
 
             else -> throw IllegalArgumentException("unsupported target value '${target.target}', allowed values is one of ${TargetType.values().toList()}")


### PR DESCRIPTION
# Summary

Just a few fixes were necessary to fix it 😄 And we could still use our existing `tscpaths` solution 😎 