### PR TITLE
Fix location of auth block.

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
@@ -138,8 +138,8 @@ class ServerRenderer @Inject constructor(
                         |        params: {
                         |          <${it.resource().fullUri.variables.map { "$it: requiredString" }.joinToString(separator = ",\n")}>
                         |        },
-                        |        failAction,${it.auth()}
-                        |      },
+                        |        failAction,
+                        |      },${it.auth()}
                         |    }
                         |}
                     """.trimMargin()


### PR DESCRIPTION
# Summary

This PR fixes the location of the auth config in our hapi server generator. A fixed gradle plugin version is available as `1.0.0-20200529111014`.