### PR TITLE
Fix joi validation regexp

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
@@ -167,7 +167,7 @@ class JoiValidatorModuleRenderer @Inject constructor(override val vrapTypeProvid
 
     fun Property.isPatternProperty() = this.name.startsWith("/") && this.name.endsWith("/")
 
-    fun Property.asRegExp() = if (this.name.equals("//")) "/.*/" else this.name // TODO katmatt: check RAML spec what // actually means
+    fun Property.asRegExp() = if (this.name.equals("//")) "/.*/" else this.name
 
     /**
      * in typescript optional properties should come after required ones

--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
@@ -100,7 +100,7 @@ class JoiValidatorModuleRenderer @Inject constructor(override val vrapTypeProvid
                 .joinToString(separator = ",\n")
         val patternProperties = this.allProperties
                 .filter { it.isPatternProperty() }
-                .map { ".pattern(${it.name}', ${it.type.toVrapType().simpleJoiName()}())" }
+                .map { ".pattern(${it.asRegExp()}, ${it.type.toVrapType().simpleJoiName()}())" }
                 .joinToString(separator = "\n")
 
         val additionalProperties = this.additionalProperties?:true
@@ -166,6 +166,8 @@ class JoiValidatorModuleRenderer @Inject constructor(override val vrapTypeProvid
         ?.filterNotNull() ?: listOf()
 
     fun Property.isPatternProperty() = this.name.startsWith("/") && this.name.endsWith("/")
+
+    fun Property.asRegExp() = if (this.name.equals("//")) "/.*/" else this.name // TODO katmatt: check RAML spec what // actually means
 
     /**
      * in typescript optional properties should come after required ones

--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
@@ -100,7 +100,7 @@ class JoiValidatorModuleRenderer @Inject constructor(override val vrapTypeProvid
                 .joinToString(separator = ",\n")
         val patternProperties = this.allProperties
                 .filter { it.isPatternProperty() }
-                .map { ".pattern(new RegExp('${it.name}'), ${it.type.toVrapType().simpleJoiName()}())" }
+                .map { ".pattern(${it.name}', ${it.type.toVrapType().simpleJoiName()}())" }
                 .joinToString(separator = "\n")
 
         val additionalProperties = this.additionalProperties?:true


### PR DESCRIPTION
#  Summary

This PR fixes the bug in our generated joi validators for regex patterns. I left a todo because of an inconsistency in our api spec and I will follow up on it as soon as @danrleyt  finishes his current task.

The fix is released as version '1.0.0-20200603102711'' and you can try it locally.