### PR TITLE
Update RMF version to be able to reproduce bug.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
 ext {
     versions = [
             spock: "1.1-groovy-2.4",
-            rmf: "0.2.0-20200214142457",
+            rmf: "0.2.0-20200612091815",
             kotlin: "1.3.10"
     ]
 


### PR DESCRIPTION
# Summary

I found a bug in RMF, but couldn't reproduce it with `rmf-codegen` because it's using an old version of RMF. Hope this doesn't break anything, but the last published RMF version behaves differently than the version we used here!