### PR TITLE
Csharp - Skip BaseResource Props

### DIFF
--- a/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/extensions/CsharpObjectTypeExtensions.kt
+++ b/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/extensions/CsharpObjectTypeExtensions.kt
@@ -8,6 +8,7 @@ import io.vrap.rmf.codegen.types.VrapType
 import io.vrap.rmf.raml.model.types.ObjectType
 
 const val ANNOTATION_ABSTRACT = "abstract"
+val BASERESOURCE_PROPS = arrayOf<String>("Id", "Version", "CreatedAt", "LastModifiedAt")
 
 interface CsharpObjectTypeExtensions : ExtensionsBase {
 

--- a/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/extensions/CsharpObjectTypeExtensions.kt
+++ b/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/extensions/CsharpObjectTypeExtensions.kt
@@ -8,7 +8,6 @@ import io.vrap.rmf.codegen.types.VrapType
 import io.vrap.rmf.raml.model.types.ObjectType
 
 const val ANNOTATION_ABSTRACT = "abstract"
-val BASERESOURCE_PROPS = arrayOf<String>("Id", "Version", "CreatedAt", "LastModifiedAt")
 
 interface CsharpObjectTypeExtensions : ExtensionsBase {
 

--- a/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/model/CsharpModelInterfaceRenderer.kt
+++ b/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/model/CsharpModelInterfaceRenderer.kt
@@ -78,15 +78,16 @@ class CsharpModelInterfaceRenderer @Inject constructor(override val vrapTypeProv
         return "${typeName}$nullableChar $propName { get; set;}"
     }
 
-    //skip if it's baseResource Prop and class interface not baseResource
+    //skip if it's already exists in the parent type
     private fun Property.shouldSkipThisProperty(objectType: ObjectType): Boolean  {
-        var parent = objectType.type?.toVrapType()?.simpleName()?.let { "$it" } ?: ""
-        val propName = this.name.capitalize()
-        val vrapType = vrapTypeProvider.doSwitch(objectType) as VrapObjectType
-        var simpleClassName = vrapType.simpleClassName
-        return parent.equals("IBaseResource", true) &&
-        !simpleClassName.equals("BaseResource",true) &&
-        BASERESOURCE_PROPS.contains(propName)
+        var hasParent = objectType.type != null;
+        if(hasParent)
+        {
+            var parent = objectType.type as ObjectType;
+            if(parent?.properties.any { it.name.equals(this.name) })
+                return true
+        }
+        return false;
     }
 
     fun ObjectType.renderTypeAsADictionaryType() : String {

--- a/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/model/CsharpModelInterfaceRenderer.kt
+++ b/languages/csharp/src/main/kotlin/io/vrap/codegen/languages/csharp/model/CsharpModelInterfaceRenderer.kt
@@ -55,7 +55,7 @@ class CsharpModelInterfaceRenderer @Inject constructor(override val vrapTypeProv
         )
     }
 
-    private fun ObjectType.toProperties() : String = this.properties.filter { !it.shouldSkipThisProperty(this) }
+    private fun ObjectType.toProperties() : String = this.properties
             .map { it.toCsharpProperty(this) }.joinToString(separator = "\n\n")
 
     private fun Property.toCsharpProperty(objectType: ObjectType): String {
@@ -64,6 +64,7 @@ class CsharpModelInterfaceRenderer @Inject constructor(override val vrapTypeProv
         val isListOfEnumProp = this.type.toVrapType() is VrapArrayType && (this.type.toVrapType() as VrapArrayType).itemType is VrapEnumType
         val propName = this.name.capitalize()
         val typeName = this.type.toVrapType().simpleName()
+        var overrideProp = this.shouldOverrideThisProperty(objectType)
 
         if(isEnumProp || isListOfEnumProp)
         {
@@ -75,11 +76,12 @@ class CsharpModelInterfaceRenderer @Inject constructor(override val vrapTypeProv
         }
 
         var nullableChar = if(!this.required && this.type.toVrapType().isValueType()) "?" else ""
-        return "${typeName}$nullableChar $propName { get; set;}"
+        var newKeyword = if(overrideProp) "new " else ""
+        return "${newKeyword}${typeName}$nullableChar $propName { get; set;}"
     }
 
-    //skip if it's already exists in the parent type
-    private fun Property.shouldSkipThisProperty(objectType: ObjectType): Boolean  {
+    //override if it's already exists in the parent type
+    private fun Property.shouldOverrideThisProperty(objectType: ObjectType): Boolean  {
         var hasParent = objectType.type != null;
         if(hasParent)
         {


### PR DESCRIPTION
Skip BaseResource Props from being presented in inherited in CSharp SDK