### PR TITLE
Release to GitHub, Native binaries on CI, README overhaul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - master
 
-name: AutoRelease
+name: AutoRelease (BinTray)
 
 jobs:
   release:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: '8'
+          java-version: "8"
 
       - name: Build and Test
         run: ./gradlew --build-cache clean check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+on: [push]
+name: AutoRelease (playground graalvm)
+jobs:
+  build-native:
+    name: Build all native images
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: Linux
+            artifact: rmf-codegen.linux
+          - os: macos-latest
+            name: Mac OS X
+            artifact: rmf-codegen.darwin
+          # windows fails silently, TODO
+          - os: windows-latest
+            name: Windows
+            artifact: rmf-codegen.win32
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+
+      - name: Build ${{ matrix.name }} native image
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: nativeImage
+          build-root-directory: tools/cli-application
+
+      - name: Upload ${{ matrix.name }} native image
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./tools/cli-application/build/graal/rmf-codegen
+
+  release:
+    name: Build JAR and Release the artifacts
+    runs-on: ubuntu-latest
+    needs: build-native
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+
+      - name: Build JAR
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build
+          build-root-directory: tools/cli-application
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d_%H-%M-%S')"
+
+      - name: Download native build artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Commit new version to README and install script
+        uses: stefanzweifel/git-auto-commit-action@v4.6.0
+        with:
+          commit_message: "TASK: Updating version in README"
+          commit_user_name: Auto Mation
+          commit_user_email: automation@commercetools.com
+          commit_author: Auto Mation <automation@commercetools.com>
+
+      # commented out in fork, activate again in official repo and when this runs only on master
+      # - name: Create Bintray Release
+      #   uses: eskatos/gradle-command-action@v1
+      #   with:
+      #     arguments: --build-cache bintrayUpload writeVersionToReadme --info --stacktrace
+      #   env:
+      #     BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+      #     BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+
+      - name: Create GitHub Release
+        id: create_github_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{steps.date.outputs.date}}
+          release_name: Release ${{steps.date.outputs.date}}
+          draft: false
+          prerelease: true
+
+      - name: Upload JAR
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+          asset_path: rmf-gen.jar
+          asset_name: rmf-codegen.jar
+          asset_content_type: application/java-archive
+
+      - name: Upload Linux Binary
+        id: upload-linux-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+          asset_path: rmf-codegen.linux/rmf-codegen
+          asset_name: rmf-codegen.linux
+          asset_content_type: application/octet-stream
+
+      - name: Upload Mac OS Binary
+        id: upload-mac-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+          asset_path: rmf-codegen.darwin/rmf-codegen
+          asset_name: rmf-codegen.darwin
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows Binary
+        id: upload-windows-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+          asset_path: rmf-codegen.win32/rmf-codegen
+          asset_name: rmf-codegen.exe
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       #   if: runner.os == 'Windows'
       #   uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Setup Windows SDK for Java 8 (if on win)
-        if: runner.os == 'Windows'
-        run: choco install windows-sdk-7.1 kb2519277
+      # - name: Setup Windows SDK for Java 8 (if on win)
+      #   if: runner.os == 'Windows'
+      #   run: choco install windows-sdk-7.1 kb2519277
 
       - name: Build ${{ matrix.name }} native image
         uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,11 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: "8"
+          java-version: "11"
+
+      - name: Setup Windows SDK (if on win)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build ${{ matrix.name }} native image
         uses: eskatos/gradle-command-action@v1
@@ -49,7 +53,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: "8"
+          java-version: "11"
 
       - name: Build JAR
         uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
-on: [push]
-name: AutoRelease (playground graalvm)
+on:
+  push:
+    branches:
+      # TODO switch to master before applying to the original repository
+      - nk-build-native-and-release-to-github
+
+name: Release
 jobs:
   build-native:
     name: Build all native images
@@ -12,7 +17,7 @@ jobs:
           - os: macos-latest
             name: Mac OS X
             artifact: rmf-codegen.darwin
-          # windows fails with a relatively unclear message, TODO
+          # TODO windows fails with a relatively unclear message
           # - os: windows-latest
           #   name: Windows
           #   artifact: rmf-codegen.win32

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 on:
   push:
     branches:
-      # TODO switch to master before applying to the original repository
-      - nk-build-native-and-release-to-github
+      - master
 
-name: Release
+name: AutoRelease (GitHub & native images)
+
 jobs:
   build-native:
     name: Build all native images
@@ -17,7 +17,7 @@ jobs:
           - os: macos-latest
             name: Mac OS X
             artifact: rmf-codegen.darwin
-          # TODO windows fails with a relatively unclear message
+          # TODO windows fails, reason not known yet
           # - os: windows-latest
           #   name: Windows
           #   artifact: rmf-codegen.win32
@@ -30,14 +30,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: "11"
-
-      # - name: Setup Windows SDK (if on win)
-      #   if: runner.os == 'Windows'
-      #   uses: ilammy/msvc-dev-cmd@v1
-
-      # - name: Setup Windows SDK for Java 8 (if on win)
-      #   if: runner.os == 'Windows'
-      #   run: choco install windows-sdk-7.1 kb2519277
 
       - name: Build ${{ matrix.name }} native image
         uses: eskatos/gradle-command-action@v1
@@ -84,15 +76,6 @@ jobs:
           commit_user_name: Auto Mation
           commit_user_email: automation@commercetools.com
           commit_author: Auto Mation <automation@commercetools.com>
-
-      # commented out in fork, activate again in official repo and when this runs only on master
-      # - name: Create Bintray Release
-      #   uses: eskatos/gradle-command-action@v1
-      #   with:
-      #     arguments: --build-cache bintrayUpload writeVersionToReadme --info --stacktrace
-      #   env:
-      #     BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-      #     BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
 
       - name: Create GitHub Release
         id: create_github_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
           - os: macos-latest
             name: Mac OS X
             artifact: rmf-codegen.darwin
-          # windows fails silently, TODO
-          - os: windows-latest
-            name: Windows
-            artifact: rmf-codegen.win32
+          # windows fails with a relatively unclear message, TODO
+          # - os: windows-latest
+          #   name: Windows
+          #   artifact: rmf-codegen.win32
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -129,13 +129,13 @@ jobs:
           asset_name: rmf-codegen.darwin
           asset_content_type: application/octet-stream
 
-      - name: Upload Windows Binary
-        id: upload-windows-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
-          asset_path: rmf-codegen.win32/rmf-codegen
-          asset_name: rmf-codegen.exe
-          asset_content_type: application/octet-stream
+      # - name: Upload Windows Binary
+      #   id: upload-windows-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+      #     asset_path: rmf-codegen.win32/rmf-codegen
+      #     asset_name: rmf-codegen.exe
+      #     asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
             name: Mac OS X
             artifact: rmf-codegen.darwin
           # TODO windows fails with a relatively unclear message
-          - os: windows-latest
-            name: Windows
-            artifact: rmf-codegen.win32
+          # - os: windows-latest
+          #   name: Windows
+          #   artifact: rmf-codegen.win32
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -138,13 +138,13 @@ jobs:
           asset_name: rmf-codegen.darwin
           asset_content_type: application/octet-stream
 
-      - name: Upload Windows Binary
-        id: upload-windows-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
-          asset_path: rmf-codegen.win32/rmf-codegen
-          asset_name: rmf-codegen.exe
-          asset_content_type: application/octet-stream
+      # - name: Upload Windows Binary
+      #   id: upload-windows-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+      #     asset_path: rmf-codegen.win32/rmf-codegen
+      #     asset_name: rmf-codegen.exe
+      #     asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
             name: Mac OS X
             artifact: rmf-codegen.darwin
           # TODO windows fails with a relatively unclear message
-          # - os: windows-latest
-          #   name: Windows
-          #   artifact: rmf-codegen.win32
+          - os: windows-latest
+            name: Windows
+            artifact: rmf-codegen.win32
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -31,9 +31,13 @@ jobs:
         with:
           java-version: "11"
 
-      - name: Setup Windows SDK (if on win)
+      # - name: Setup Windows SDK (if on win)
+      #   if: runner.os == 'Windows'
+      #   uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup Windows SDK for Java 8 (if on win)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        run: choco install windows-sdk-7.1 kb2519277
 
       - name: Build ${{ matrix.name }} native image
         uses: eskatos/gradle-command-action@v1
@@ -134,13 +138,13 @@ jobs:
           asset_name: rmf-codegen.darwin
           asset_content_type: application/octet-stream
 
-      # - name: Upload Windows Binary
-      #   id: upload-windows-asset
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_github_release.outputs.upload_url }}
-      #     asset_path: rmf-codegen.win32/rmf-codegen
-      #     asset_name: rmf-codegen.exe
-      #     asset_content_type: application/octet-stream
+      - name: Upload Windows Binary
+        id: upload-windows-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+          asset_path: rmf-codegen.win32/rmf-codegen
+          asset_name: rmf-codegen.exe
+          asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ generated-code/out
 languages/javalang/builder-renderer/generated-code/src/main
 rmf-gen.jar
 rmf-codegen.*
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ cache/
 requests.log
 composer.lock
 rmf-codegen.iml
-rmf-codegen.iml
 generated-code/build
 generated-code/out
 languages/javalang/builder-renderer/generated-code/src/main
 rmf-gen.jar
+rmf-codegen.*

--- a/README.md
+++ b/README.md
@@ -1,47 +1,129 @@
-# rmf-codegen
+# RMF-Codegen
 
-[![Build Status](https://travis-ci.com/vrapio/rmf-codegen.svg?branch=master)](https://travis-ci.com/vrapio/rmf-codegen)
-
-Provides RAML code generators based on [RMF](https://github.com/vrapio/rest-modeling-framework).
+RAML API client code generators based on the [RMF (REST Modeling Framework)](https://github.com/vrapio/rest-modeling-framework).
 The code generators are written in [kotlin](https://kotlinlang.org/).
 
-# Supported languages & frameworks
+## Supported output targets
 
-* Java types for JSON serialization/deserialization of RAML types via [Jackson](https://github.com/FasterXML/jackson)
-* Java client for accessing RAML resources via [Spring RestTemplate](https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#webmvc-resttemplate)
-* TypeScript types generated from RAML types
-* TypeScript types for validating JSON payloads via [hapijs/joi](https://github.com/hapijs/joi)
+- `JAVA_CLIENT`:
+  - Java types for JSON serialization/deserialization of RAML types via [Jackson](https://github.com/FasterXML/jackson)
+  - Java client for accessing RAML resources via [Spring RestTemplate](https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#webmvc-resttemplate)
+- `TYPESCRIPT_CLIENT`:
+  - TypeScript types generated from RAML types
+  - TypeScript types for validating JSON payloads via [hapijs/joi](https://github.com/hapijs/joi)
+- `CSHARP_CLIENT`
+- `PHP_CLIENT`
+- `POSTMAN`: Collection file for the [Postman API Client](https://www.postman.com/product/api-client/)
+- `RAML_DOC`: Emits RAML files targeted at generating robust and stable API documentation. Fully flattens and resolves types and resources. The output RAML has a fixed canonical filesystem structure and every type or resource file contains all information to fully document it. It's used by the [commercetools-docs-kit](https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-theme-api-docs)
 
-# Install `rmf-codegen` CLI
+## Install `rmf-codegen` CLI
 
 To install the rmf-codegen cli, run the following command
+
 ```
 curl -o- -s https://raw.githubusercontent.com/vrapio/rmf-codegen/master/scripts/install.sh | bash
 ```
-You will find a new command available  `rmf-codegen`, you can check that all is good by executing `rmf-codegen -v`
 
-# Build a native executable with GraalVM
+You will find a new command available `rmf-codegen`, you can check that all is good by executing `rmf-codegen -v`
 
-You can also build a native executable with the following commands:
+## NPM wrapper package
+
+The [`commercetools-docs-kit`](https://github.com/commercetools/commercetools-docs-kit) provides an NPM package that automates the download of the JAR and provides the `rmf-codegen` command to JavaScript projects without global installation. (find at [NPM](https://www.npmjs.com/login?next=/package/@commercetools-docs/rmf-codegen))
+
+## Usage
+
+General Usage:
+
 ```
+Usage: rmf-codegen [-hv] [COMMAND]
+Allows to validate RAML files and generate code from them
+  -h, --help                display this help message
+  -v, --version             print version information and exit
+Commands:
+  generate                  Generate source code from a RAML specification.
+  verify                    Allows to verify if a raml spec is valid.
+```
+
+Generating Client SDKs or normalized RAML for documentation:
+
+```
+Usage: rmf-codegen generate [-hvw] [-b=<basePackageName>]
+                            [-c=<clientPackageName>] [-m=<modelPackageName>]
+                            -o=<outputFolder> [-s=<sharedPackage>] -t=<target>
+                            <ramlFileLocation>
+Generate source code from a RAML specification.
+  <ramlFileLocation>        Api file location
+  -b, --base-package=<basePackageName>
+                            The base package, this package in case the model or
+                            client models aren't provided
+  -c, --client-package=<clientPackageName>
+                            The client package, This will be used as the package
+                            for the client stub.
+  -h, --help                display this help message
+  -m, --model-package=<modelPackageName>
+                            The models package, this will be used as the model
+                            package in the generated code.
+  -o, --output-folder=<outputFolder>
+                            Output folder for generated files.
+  -s, --shared-package=<sharedPackage>
+                            The shared package to be used for the generated code.
+  -t, --target=<target>     Specifies the code generation target
+                            Valid values: JAVA_CLIENT, TYPESCRIPT_CLIENT,
+                            CSHARP_CLIENT, PHP_CLIENT, PHP_BASE, PHP_TEST,
+                            POSTMAN, RAML_DOC
+  -v, --verbose             If set, this would move the verbosity level to debug.
+  -w, --watch               Watches the files for changes
+
+```
+
+Validating a RAML API:
+
+```
+Usage: rmf-codegen verify [-hw] <ramlFileLocation>
+Allows to verify if a RAML spec is valid.
+  <ramlFileLocation>        Api file location
+  -h, --help                display this help message
+  -w, --watch               Watches the files for changes
+```
+
+## Development
+
+### Build the "fat jar"
+
+A single "fat jar" is built with the following commands:
+
+```sh
+cd tools/cli-application/
+../../gradlew build
+```
+
+The JAR can then be found at `./rmf-gen.jar`
+
+### Build a native executable with GraalVM
+
+A native executable is built with the following commands:
+
+```sh
 cd tools/cli-application/
 ../../gradlew nativeImage
 ```
-The native executable can then be found at `build/graal/rmf-codegen`.
-It's currently only tested with Mac OS X.
 
-# Why did we choose kotlin for writing our code generators?
+The native executable can then be found at `./tools/cli-application/build/graal/rmf-codegen`.
+It's currently only tested with Mac OS X. It emits error messages but the functionality works.
+
+### Why did we choose kotlin for writing our code generators?
 
 We choose kotlin because of the following features:
-* extension methods, which allow us to add methods to our RMF model types
-* multin-line template string with embedded expressions, which allows us to keep the templates and the code in the same file
-* it integrates very well with our RMF Java types
-* it has very good IDE support, which makes writing code generators very easy
 
-These features make developing code generators for different programming languges/frameworks very easy. 
+- extension methods, which allow us to add methods to our RMF model types
+- multi-line template string with embedded expressions, which allows us to keep the templates and the code in the same file
+- it integrates very well with our RMF Java types
+- it has very good IDE support, which makes writing code generators very easy
+
+These features make developing code generators for different programming languges/frameworks very easy.
 An example of a Java Spring code generator can be found here: [codegen-renderers/src/main/kotlin/io/vrap/codegen/languages/java/client/SpringClientRenderer.kt](https://github.com/vrapio/rmf-codegen/blob/master/codegen-renderers/src/main/kotlin/io/vrap/codegen/languages/java/client/SpringClientRenderer.kt)
 
-# Running tests against your own raml files
+# Running tests against your own RAML files
 
-Our `TestCodeGenerator` test can be run against a user provided RAML file by setting 
+Our `TestCodeGenerator` test can be run against a user provided RAML file by setting
 the `TEST_RAML_FILE` environment variable to the file path.

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.11.0'
     id 'org.inferred.processors' version '3.3.0'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'com.palantir.graal' version '0.6.0'
+    id 'com.palantir.graal' version '0.7.2'
 }
 
 ext {

--- a/tools/cli-application/build.gradle
+++ b/tools/cli-application/build.gradle
@@ -19,8 +19,8 @@ graal {
     mainClass 'io.vrap.rmf.codegen.cli.MainKt'
     outputName 'rmf-codegen'
     javaVersion '11'
-    // force building a native image and rather let if fail instead of building a fallback image
-    option '--no-fallback --allow-incomplete-classpath --enable-http --enable-https'
+    // force building a native image and rather let if fail at runtime instead of building a fallback image
+    option '--allow-incomplete-classpath'
 }
 
 publishing {

--- a/tools/cli-application/build.gradle
+++ b/tools/cli-application/build.gradle
@@ -18,6 +18,7 @@ apply plugin: 'com.palantir.graal'
 graal {
     mainClass 'io.vrap.rmf.codegen.cli.MainKt'
     outputName 'rmf-codegen'
+    javaVersion '11'
 }
 
 publishing {

--- a/tools/cli-application/build.gradle
+++ b/tools/cli-application/build.gradle
@@ -19,6 +19,8 @@ graal {
     mainClass 'io.vrap.rmf.codegen.cli.MainKt'
     outputName 'rmf-codegen'
     javaVersion '11'
+    // force building a native image and rather let if fail instead of building a fallback image
+    option '--no-fallback --allow-incomplete-classpath --enable-http --enable-https'
 }
 
 publishing {


### PR DESCRIPTION
When using RMF-Codegen in documenation we found it's minimal documentation and not only slightly hidden release artifact on Bintray hinders adoption and proper usage. 

Here's how the releases would look like: https://github.com/nkuehn/rmf-codegen/releases 

This 
 * Overhauls the README and adds the CLI help output to the README so you can see all the glory without having to download it
 * Adds an additional release CI workflow that builds a JAR and Mac / Linux native binaries and publishes these as a GitHub release, which has the advantage to have a browseable UI

General hints:
 * windows binaries not built, there's some problem with the build which (I think) should only be tackled after the native builds are error free on the other platforms. 
 * the linked javascript / NPM package is no merged and published yet in the docs kit (PR https://github.com/commercetools/commercetools-docs-kit/pull/760 ) - not an issue since we don't have a lot of external contributors yet. 
 * java 11 used for the binary builds because the windows dependencies are there by default which they aren't for Java 8 (plus, a newer VM anyways).  The JAR and general implementation stays on java 8 though. 

