### PR TITLE
update hapi params to use joi objects

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
@@ -142,9 +142,9 @@ class ServerRenderer @Inject constructor(
                         |        options: {
                         |          abortEarly: false
                         |        },
-                        |        query: {
+                        |        query: Joi.object({
                         |          <${it.queryParameters.map { "${it.name}: ${it.toJoiSchema()}" }.joinToString(separator = ",\n")}>
-                        |        },
+                        |        }),
                         |        failAction,
                         |      },${it.auth()}
                         |    }

--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/server/ServerRenderer.kt
@@ -136,9 +136,9 @@ class ServerRenderer @Inject constructor(
                         |   options: {
                         |      validate: {
                         |        <${if(it.hasBody()) "payload: ${it.bodies[0].type.toVrapType().simpleJoiName()}()," else ""}>
-                        |        params: {
+                        |        params: Joi.object({
                         |          <${it.resource().fullUri.variables.map { "$it: requiredString" }.joinToString(separator = ",\n")}>
-                        |        },
+                        |        }),
                         |        options: {
                         |          abortEarly: false
                         |        },


### PR DESCRIPTION
In Hapi v20, This PR updates the code generator to change Joi params now have to be `Joi.object()`