### PR TITLE
pass false to joi object unknown method

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
@@ -120,7 +120,7 @@ class JoiValidatorModuleRenderer constructor(override val vrapTypeProvider: Vrap
         val patternProperties = this.allProperties
                 .filter { it.isPatternProperty() }.joinToString(separator = "\n") { ".pattern(${it.asRegExp()}, ${it.type.toVrapType().simpleJoiName()}())" }
         val additionalProperties = this.additionalProperties?:true
-        val unknown = if (additionalProperties) ".unknown()" else ""
+        val unknown = if (additionalProperties) ".unknown(false)" else ""
         return if (patternProperties.isNullOrEmpty())
             """ |Joi.object()${unknown}.keys({
                 |   <$nonPatternProperties>

--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/joi/JoiValidatorModuleRenderer.kt
@@ -120,7 +120,7 @@ class JoiValidatorModuleRenderer constructor(override val vrapTypeProvider: Vrap
         val patternProperties = this.allProperties
                 .filter { it.isPatternProperty() }.joinToString(separator = "\n") { ".pattern(${it.asRegExp()}, ${it.type.toVrapType().simpleJoiName()}())" }
         val additionalProperties = this.additionalProperties?:true
-        val unknown = if (additionalProperties) ".unknown(false)" else ""
+        val unknown = if (!additionalProperties) ".unknown(false)" else ""
         return if (patternProperties.isNullOrEmpty())
             """ |Joi.object()${unknown}.keys({
                 |   <$nonPatternProperties>


### PR DESCRIPTION
We are currently using joi's [object.unknown](https://joi.dev/api/?v=17.4.0#objectunknownallow) method call with the default setting. This means that we're ignoring unknown keys and don't pass them on to the handler. We would like to make this stricter, and throw when an unknown field is being passed. So this PR passed `false` into the method call to enable throwing.

Resolves #220
References https://github.com/commercetools/commercetools-importer/issues/1762

