### PR TITLE
Minor fixes to update the Python generator to work again

### DIFF
--- a/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/InitFileProducer.kt
+++ b/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/InitFileProducer.kt
@@ -36,7 +36,7 @@ class InitFileProducer constructor(
                 it.moduleName()
             }
             .map {
-                var moduleName = it.key.split(".")[1]
+                var moduleName = it.key.split(".").last()
                 "from .$moduleName import *  # noqa"
             }
             .joinToString(separator = "\n")

--- a/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/PythonModelRenderer.kt
+++ b/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/PythonModelRenderer.kt
@@ -20,6 +20,7 @@ import io.vrap.rmf.codegen.rendring.utils.keepIndentation
 import io.vrap.rmf.codegen.types.VrapEnumType
 import io.vrap.rmf.codegen.types.VrapObjectType
 import io.vrap.rmf.codegen.types.VrapTypeProvider
+import io.vrap.rmf.codegen.types.VrapScalarType
 import io.vrap.rmf.raml.model.types.AnyType
 import io.vrap.rmf.raml.model.types.IntersectionType
 import io.vrap.rmf.raml.model.types.NilType
@@ -243,15 +244,23 @@ class PythonModelRenderer constructor(
     }
 
     private fun StringType.renderStringType(): String {
-        val vrapType = this.toVrapType() as VrapEnumType
+        val vrapType = this.toVrapType()
 
-        return """
-        |class ${vrapType.simpleClassName}(enum.Enum):
-        |   <${toDocString().escapeAll()}>
-        |   <${this.renderEnumValues()}>
-        |
-        |
-        """.trimMargin()
+        return when (vrapType) {
+            is VrapEnumType ->
+                return """
+                |class ${vrapType.simpleClassName}(enum.Enum):
+                |   <${toDocString().escapeAll()}>
+                |   <${this.renderEnumValues()}>
+                |
+                |
+                """.trimMargin()
+            is VrapScalarType -> """
+                |${this.name} = ${vrapType.scalarType}
+            """.trimMargin()
+            else -> ""
+        }
+
     }
 
     private fun StringType.renderEnumValues(): String = enumValues()

--- a/tools/cli-application/src/main/kotlin/io/vrap/rmf/codegen/cli/GenerateSubcommand.kt
+++ b/tools/cli-application/src/main/kotlin/io/vrap/rmf/codegen/cli/GenerateSubcommand.kt
@@ -160,7 +160,7 @@ class GenerateSubcommand : Callable<Int> {
     private fun generate(fileLocation: Path, target: GenerationTarget, generatorConfig: CodeGeneratorConfig): Int {
         val generateDuration = measureTimeMillis {
             val generatorComponent: GeneratorComponent
-            if (fileLocation.endsWith(".raml")) {
+            if (fileLocation.toString().endsWith(".raml")) {
                 val apiProvider = RamlApiProvider(fileLocation)
                 generatorComponent = when (target) {
                     GenerationTarget.JAVA_CLIENT -> {


### PR DESCRIPTION
This fixes three issues:
 - The `.raml` check on the fileLocation failed on my laptop 
 - The platform raml spec introduced a StringType which was not an enum, now handled correctly.
 - Use `.last()` for getting the last part of a module name instead of the hardcoded the [1]