### PR TITLE
Python: Fix handling of pattern properties

### DIFF
--- a/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/PythonSchemaRenderer.kt
+++ b/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/PythonSchemaRenderer.kt
@@ -179,7 +179,7 @@ class PythonSchemaRenderer constructor(
             return """
             |helpers.RegexField(
             |    unknown=marshmallow.EXCLUDE,
-            |    pattern=re.compile("${prop.pattern}"),
+            |    metadata={'pattern': re.compile("${prop.pattern}")},
             |    type=${prop.type.PyMarshmallowFieldClass()}(
             |       ${kwargs.joinToString(separator = ",\n      ")}
             |    )

--- a/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/PythonSchemaRenderer.kt
+++ b/languages/python/src/main/kotlin/io/vrap/codegen/languages/python/model/PythonSchemaRenderer.kt
@@ -124,25 +124,21 @@ class PythonSchemaRenderer constructor(
 
             if (allProperties.any { it.isPatternProperty() }) {
                 return """
-                |@marshmallow.post_load
-                |def post_load(self, data, **kwargs):
-                |    data = typing.cast(helpers.RegexField, self.fields["_regex"]).postprocess(data)
-                |    return models.${modelType.simpleClassName}(**data)
-                |
                 |@marshmallow.pre_load
                 |def pre_load(self, data, **kwargs):
-                |    data = typing.cast(helpers.RegexField, self.fields["_regex"]).preprocess(data)
-                |    return data
+                |    field = typing.cast(helpers.RegexField, self.fields["_regex"])
+                |    return field.pre_load(self, data)
                 |
-                |@marshmallow.pre_dump
-                |def pre_dump(self, data, **kwargs):
-                |    data = typing.cast(helpers.RegexField, self.fields["_regex"]).preprocess(data)
-                |    return data
+                |@marshmallow.post_load(pass_original=True)
+                |def post_load(self, data, original_data, **kwargs):
+                |    field = typing.cast(helpers.RegexField, self.fields["_regex"])
+                |    data = field.post_load(data, original_data)
+                |    return models.${modelType.simpleClassName}(**data)
                 |
-                |@marshmallow.post_dump
-                |def post_dump(self, data, **kwargs):
-                |    data = typing.cast(helpers.RegexField, self.fields["_regex"]).postprocess(data)
-                |    return data
+                |@marshmallow.post_dump(pass_original=True)
+                |def post_dump(self, data, original_data, **kwargs):
+                |    field = typing.cast(helpers.RegexField, self.fields["_regex"])
+                |    return field.post_dump(data, original_data)
                 """.trimMargin()
             } else {
                 return """


### PR DESCRIPTION
Don't render the names as `//` but instead use the `**kwargs` syntax