### PR TITLE
Add missing generic return to execute function

### DIFF
--- a/languages/php/src/main/kotlin/io/vrap/codegen/languages/php/model/PhpMethodRenderer.kt
+++ b/languages/php/src/main/kotlin/io/vrap/codegen/languages/php/model/PhpMethodRenderer.kt
@@ -155,7 +155,7 @@ class PhpMethodRenderer constructor(override val vrapTypeProvider: VrapTypeProvi
             |     * @template T of JsonObject
             |     * @psalm-param ?class-string<T> $!resultType
             |     *
-            |     * @return ${returnTypes.joinToString("|")}|T|null
+            |     * @return null|T|${returnTypes.joinToString("|")}
             |     */
             |    public function execute(array $!options = [], string $!resultType = null)
             |    {

--- a/languages/php/src/main/kotlin/io/vrap/codegen/languages/php/model/PhpMethodRenderer.kt
+++ b/languages/php/src/main/kotlin/io/vrap/codegen/languages/php/model/PhpMethodRenderer.kt
@@ -155,7 +155,7 @@ class PhpMethodRenderer constructor(override val vrapTypeProvider: VrapTypeProvi
             |     * @template T of JsonObject
             |     * @psalm-param ?class-string<T> $!resultType
             |     *
-            |     * @return null|${returnTypes.joinToString("|")}
+            |     * @return ${returnTypes.joinToString("|")}|T|null
             |     */
             |    public function execute(array $!options = [], string $!resultType = null)
             |    {


### PR DESCRIPTION
As the execute method is not returning the generic Template value, psalm is complaining about undefined methods when you use a returnType. With this the generic is also returned

![image](https://user-images.githubusercontent.com/1322557/170953811-772815ad-a0ab-4946-9767-9d32de59dafc.png)
