### PR TITLE
Go: Return `GenericRequestError` for unhandled http status codes

### DIFF
--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/ClientFileProducer.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/ClientFileProducer.kt
@@ -189,6 +189,7 @@ class ClientFileProducer constructor(
                 |type GenericRequestError struct {
                 |    Content    []byte
                 |    StatusCode int
+                |    Response   *http.Response
                 |}
                 |
                 |func (e GenericRequestError) Error() string {

--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/MethodRenderer.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/MethodRenderer.kt
@@ -328,14 +328,7 @@ class GoMethodRenderer constructor(
                         |    return ${returnValue}nil
                         """.trimMargin()
                     } else {
-                        """
-                        |case ${statusCodes.joinToString(", ")}:
-                        |    result := GenericRequestError{
-                        |        StatusCode: resp.StatusCode,
-                        |        Content:    content,
-                        |    }
-                        |    return ${returnValue}result
-                        """.trimMargin()
+                        ""
                     }
                 } else {
                     if (it.key.success) {
@@ -370,7 +363,12 @@ class GoMethodRenderer constructor(
         |switch resp.StatusCode {
         |    <$switchStatements>
         |    default:
-        |        return ${returnValue}fmt.Errorf("unhandled StatusCode: %d", resp.StatusCode)
+        |        result := GenericRequestError{
+        |            StatusCode: resp.StatusCode,
+        |            Content:    content,
+        |            Response:   resp,
+        |        }
+        |        return ${returnValue}result
         |}
         """
     }


### PR DESCRIPTION
If the HTTP status code returned by the server is not defined in the RAML
specs we would previously return an error indicating this. Instead we
now return a `GenericRequestError` with the status code, body and
response object.