### PR TITLE
Go: Implement support for pattern properties

### DIFF
--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/GoObjectTypeExtensions.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/GoObjectTypeExtensions.kt
@@ -1,6 +1,7 @@
 package io.vrap.codegen.languages.go
 
 import io.vrap.codegen.languages.extensions.ExtensionsBase
+import io.vrap.codegen.languages.extensions.isPatternProperty
 import io.vrap.rmf.codegen.types.*
 import io.vrap.rmf.raml.model.types.*
 import org.eclipse.emf.ecore.EObject
@@ -192,4 +193,18 @@ interface GoObjectTypeExtensions : ExtensionsBase {
         }
         return false
     }
+
+    fun Property.patternName(): String {
+        return if (this.isPatternProperty()) {
+            val otherProps = (this.eContainer() as ObjectType).properties
+            return if (otherProps.filter { it.isPatternProperty() }.count() > 1) {
+                throw Exception("Multiple pattern properties is not supported")
+            } else {
+                "ExtraValues"
+            }
+        }
+        else
+            this.name
+    }
+
 }

--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/GoStringExtension.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/GoStringExtension.kt
@@ -35,6 +35,9 @@ fun String.goClientFileName(): String {
 }
 
 fun String.exportName(): String {
+    if (this.contains("/")) {
+        throw Exception("Invalid identifier name: " + this)
+    }
     if (this[0].isUpperCase()) {
         return this
     }

--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/ClientFileProducer.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/ClientFileProducer.kt
@@ -257,8 +257,9 @@ class ClientFileProducer constructor(
                 |}
                 |
                 |func decodeStruct(input interface{}, result interface{}) error {
+                |    meta := &mapstructure.Metadata{}
                 |    decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-                |        Metadata: nil,
+                |        Metadata: meta,
                 |        DecodeHook: mapstructure.ComposeDecodeHookFunc(
                 |            toTimeHookFunc()),
                 |        Result: result,
@@ -270,7 +271,22 @@ class ClientFileProducer constructor(
                 |    if err := decoder.Decode(input); err != nil {
                 |        return err
                 |    }
+                |
+                |    if val, ok := result.(DecodeStruct); ok {
+                |        if raw, ok := input.(map[string]interface{}); ok {
+                |            unused := make(map[string]interface{})
+                |            for _, key := range meta.Unused {
+                |                unused[key] = raw[key]
+                |            }
+                |            val.DecodeStruct(unused)
+                |        }
+                |    }
+                |
                 |    return err
+                |}
+                |
+                |type DecodeStruct interface {
+                |    DecodeStruct(map[string]interface{}) error
                 |}
             """.trimMargin().keepIndentation()
         )

--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/RequestBuilder.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/RequestBuilder.kt
@@ -105,16 +105,16 @@ class RequestBuilder constructor(
             }
             .joinToString(separator = ", ")
 
-        val assignments =
-            this.relativeUri.variables
-                .map { it.goName() }
-                .map { "$it: rb.$it," }
-                .plus(
-                    (this.fullUri.variables.asList() - this.relativeUri.variables.asList())
-                        .map { it.goName() }
-                        .map { "$it: rb.$it," }
-                )
-                .joinToString(separator = "\n")
+        // val assignments =
+        //     this.relativeUri.variables
+        //         .map { it.goName() }
+        //         .map { "$it: rb.$it," }
+        //         .plus(
+        //             (this.fullUri.variables.asList() - this.relativeUri.variables.asList())
+        //                 .map { it.goName() }
+        //                 .map { "$it: rb.$it," }
+        //         )
+        //         .joinToString(separator = "\n")
 
         val endpoint = transformUriTemplate(this.fullUri.template)
         return """


### PR DESCRIPTION
The pattern properties are added to the struct. If only one pattern is
in the struct (most often the case) the name `ExtraValues` is used.

Otherwise the index is appended (e.g. `ExtraValues2`)