### PR TITLE
BMU-779: encode path params in typescript sdk for proper escaped URI

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/client/files_producers/ClientFileProducer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/client/files_producers/ClientFileProducer.kt
@@ -160,7 +160,8 @@ export function buildRelativeUri(commonRequest: ClientRequest): string {
   var uri: string = commonRequest.uriTemplate as string
 
   for (const param in pathMap) {
-    uri = uri.replace(`{${'$'}{param}}`, `${'$'}{pathMap[param]}`)
+    const value = encodeURIComponent(`${'$'}{pathMap[param]}`)
+    uri = uri.replace(`{${'$'}{param}}`, `${'$'}{value}`)
   }
 
   const resQuery = formatQueryString(commonRequest.queryParams || {})


### PR DESCRIPTION
The path params inside of the URI are not escaped. This leads to URLs that are not valid.

Example: A customer of ours is using special characters in its product key: `123455[P]`

The URL to update or retrieve the product by key is constructed then like `https://api.europe-west1.gcp.commercetools.com/konrad-dev-002/products/key=518210[P]'`

After the introduction of the change, the constructed url will look like this: `https://api.europe-west1.gcp.commercetools.com/konrad-dev-002/products/key=1234%5BP%5D`

 