### PR TITLE
fix: switched from values.Set to values.Add 

### DIFF
--- a/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/MethodRenderer.kt
+++ b/languages/go/src/main/kotlin/io/vrap/codegen/languages/go/client/MethodRenderer.kt
@@ -145,11 +145,10 @@ class GoMethodRenderer(
 
             if (it.isPatternProperty()) {
                 val name = it.paramName().exportName()
-                // TODO: We could validate the key against the regex
                 """
                 |for k, v := range input.$name {
                 |    for _, x := range v {
-                |        values.Set(k, x)
+                |        values.Add(k, x)
                 |    }
                 |}
                 """.trimMargin()


### PR DESCRIPTION
We currently overwrite values being set in GET queries. This changes the generator to use Add instead, which will append values