### PR TITLE
[Chore] Add Missing `originalRequest` Field to ClientResponse Interface

### DIFF
--- a/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/client/files_producers/ClientFileProducer.kt
+++ b/languages/typescript/src/main/kotlin/io/vrap/codegen/languages/typescript/client/files_producers/ClientFileProducer.kt
@@ -59,6 +59,7 @@ export type ClientResponse<T = any> = {
   body: T;
   statusCode?: number;
   headers?: Object;
+  originalRequest?: ClientRequest;
 };
 
 export type executeRequest = (request: ClientRequest) => Promise<ClientResponse>


### PR DESCRIPTION
### Summary
Add missing field for ClientResponse interface

### Task to be completed
- [x] add missing originalResponse field to ClientResponse interface

### Fixes
[721](https://github.com/commercetools/commercetools-sdk-typescript/pull/721) failing tests