### PR TITLE
Add ErrorResponseStructureRule validation rule

### DIFF
--- a/ctp-validators/src/main/kotlin/com/commercetools/rmf/validators/ErrorResponseStructureRule.kt
+++ b/ctp-validators/src/main/kotlin/com/commercetools/rmf/validators/ErrorResponseStructureRule.kt
@@ -1,0 +1,74 @@
+package com.commercetools.rmf.validators
+
+import io.vrap.rmf.raml.model.resources.Method
+import io.vrap.rmf.raml.model.resources.Resource
+import io.vrap.rmf.raml.model.types.ArrayType
+import io.vrap.rmf.raml.model.types.ObjectType
+import org.eclipse.emf.common.util.Diagnostic
+import java.util.*
+
+@ValidatorSet
+class ErrorResponseStructureRule(severity: RuleSeverity, options: List<RuleOption>? = null) : ResourcesRule(severity, options) {
+
+    private val exclude: List<String> =
+        (options?.filter { ruleOption -> ruleOption.type.lowercase(Locale.getDefault()) == RuleOptionType.EXCLUDE.toString() }?.map { ruleOption -> ruleOption.value }?.plus("") ?: defaultExcludes)
+
+    override fun caseMethod(method: Method): List<Diagnostic> {
+        val validationResults: MutableList<Diagnostic> = ArrayList()
+        val resource = method.eContainer() as Resource
+        val methodId = "${method.method.name} ${resource.fullUri.template}"
+
+        if (exclude.contains(methodId)) {
+            return validationResults
+        }
+
+        val errorResponses = method.responses.filter { response -> response.statusCode.toInt() >= 400 }
+
+        errorResponses.forEach { response ->
+            val statusCode = response.statusCode
+            response.bodies.forEach { body ->
+                val bodyType = body.type
+                if (bodyType is ObjectType) {
+                    if (bodyType.properties.none { it.name == "statusCode" }) {
+                        validationResults.add(create(method, "Method \"{0} {1}\" error response (status {2}) body type must have a \"statusCode\" property", method.method.name, resource.fullUri.template, statusCode))
+                    }
+
+                    if (bodyType.properties.none { it.name == "message" }) {
+                        validationResults.add(create(method, "Method \"{0} {1}\" error response (status {2}) body type must have a \"message\" property", method.method.name, resource.fullUri.template, statusCode))
+                    }
+
+                    val errorsProperty = bodyType.properties.find { it.name == "errors" }
+                    if (errorsProperty == null) {
+                        validationResults.add(warning(method, "Method \"{0} {1}\" error response (status {2}) body type should have an \"errors\" array property", method.method.name, resource.fullUri.template, statusCode))
+                    } else if (errorsProperty.type is ArrayType) {
+                        val itemsType = (errorsProperty.type as ArrayType).items
+                        if (itemsType is ObjectType) {
+                            if (itemsType.properties.none { it.name == "code" }) {
+                                validationResults.add(create(method, "Method \"{0} {1}\" error response (status {2}) error items must have a \"code\" property", method.method.name, resource.fullUri.template, statusCode))
+                            }
+                            if (itemsType.properties.none { it.name == "message" }) {
+                                validationResults.add(create(method, "Method \"{0} {1}\" error response (status {2}) error items must have a \"message\" property", method.method.name, resource.fullUri.template, statusCode))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return validationResults
+    }
+
+    companion object : ValidatorFactory<ErrorResponseStructureRule> {
+        private val defaultExcludes by lazy { listOf("") }
+
+        @JvmStatic
+        override fun create(options: List<RuleOption>?): ErrorResponseStructureRule {
+            return ErrorResponseStructureRule(RuleSeverity.ERROR, options)
+        }
+
+        @JvmStatic
+        override fun create(severity: RuleSeverity, options: List<RuleOption>?): ErrorResponseStructureRule {
+            return ErrorResponseStructureRule(severity, options)
+        }
+    }
+}

--- a/ctp-validators/src/test/groovy/com/commercetools/rmf/validators/ValidatorRulesTest.groovy
+++ b/ctp-validators/src/test/groovy/com/commercetools/rmf/validators/ValidatorRulesTest.groovy
@@ -528,4 +528,29 @@ class ValidatorRulesTest extends Specification implements ValidatorFixtures {
         then:
         result.validationResults.size() == 9
     }
+
+    def "error response structure rule"() {
+        when:
+        def options = singletonList(new RuleOption(RuleOptionType.EXCLUDE.toString(), "GET /excluded"))
+        def validators = Arrays.asList(new ResourcesValidator(Arrays.asList(ErrorResponseStructureRule.create(options))))
+        def uri = uriFromClasspath("/error-response-structure-rule.raml")
+        def result = new RamlModelBuilder(validators).buildApi(uri)
+        then:
+        result.validationResults.size() == 5
+        result.validationResults[0].message == "Method \"GET /missing-status-code\" error response (status 400) body type must have a \"statusCode\" property"
+        result.validationResults[1].message == "Method \"GET /missing-message\" error response (status 404) body type must have a \"message\" property"
+        result.validationResults[2].message == "Method \"GET /missing-errors-array\" error response (status 500) body type should have an \"errors\" array property"
+        result.validationResults[2].severity == Diagnostic.WARNING
+        result.validationResults[3].message == "Method \"GET /invalid-error-items\" error response (status 400) error items must have a \"code\" property"
+        result.validationResults[4].message == "Method \"GET /invalid-error-items\" error response (status 400) error items must have a \"message\" property"
+    }
+
+    def "error response structure rule without exclusions"() {
+        when:
+        def validators = Arrays.asList(new ResourcesValidator(Arrays.asList(ErrorResponseStructureRule.create(emptyList()))))
+        def uri = uriFromClasspath("/error-response-structure-rule.raml")
+        def result = new RamlModelBuilder(validators).buildApi(uri)
+        then:
+        result.validationResults.size() == 6
+    }
 }

--- a/ctp-validators/src/test/resources/error-response-structure-rule.raml
+++ b/ctp-validators/src/test/resources/error-response-structure-rule.raml
@@ -1,0 +1,125 @@
+#%RAML 1.0
+title: error response structure rule
+
+types:
+  ValidErrorResponse:
+    type: object
+    properties:
+      statusCode:
+        type: integer
+      message:
+        type: string
+      errors:
+        type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+
+  MissingStatusCodeError:
+    type: object
+    properties:
+      message:
+        type: string
+      errors:
+        type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+
+  MissingMessageError:
+    type: object
+    properties:
+      statusCode:
+        type: integer
+      errors:
+        type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+
+  MissingErrorsArrayError:
+    type: object
+    properties:
+      statusCode:
+        type: integer
+      message:
+        type: string
+
+  InvalidErrorItems:
+    type: object
+    properties:
+      statusCode:
+        type: integer
+      message:
+        type: string
+      errors:
+        type: array
+        items:
+          type: object
+          properties:
+            detail:
+              type: string
+
+/valid:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: object
+      400:
+        body:
+          application/json:
+            type: ValidErrorResponse
+
+/missing-status-code:
+  get:
+    responses:
+      400:
+        body:
+          application/json:
+            type: MissingStatusCodeError
+
+/missing-message:
+  get:
+    responses:
+      404:
+        body:
+          application/json:
+            type: MissingMessageError
+
+/missing-errors-array:
+  get:
+    responses:
+      500:
+        body:
+          application/json:
+            type: MissingErrorsArrayError
+
+/invalid-error-items:
+  get:
+    responses:
+      400:
+        body:
+          application/json:
+            type: InvalidErrorItems
+
+/excluded:
+  get:
+    responses:
+      400:
+        body:
+          application/json:
+            type: MissingStatusCodeError

--- a/ctp-validators/src/test/resources/error-response-structure-rule.raml
+++ b/ctp-validators/src/test/resources/error-response-structure-rule.raml
@@ -6,8 +6,10 @@ types:
     type: object
     properties:
       statusCode:
+        description: HTTP status code
         type: integer
       message:
+        description: Error message
         type: string
       errors:
         type: array
@@ -15,6 +17,7 @@ types:
           type: object
           properties:
             code:
+              description: Error code
               type: string
             message:
               type: string
@@ -38,6 +41,7 @@ types:
     type: object
     properties:
       statusCode:
+        description: HTTP status code
         type: integer
       errors:
         type: array
@@ -47,6 +51,7 @@ types:
             code:
               type: string
             message:
+              description: Error message
               type: string
 
   MissingErrorsArrayError:
@@ -63,6 +68,7 @@ types:
       statusCode:
         type: integer
       message:
+        description: Error message
         type: string
       errors:
         type: array
@@ -70,6 +76,7 @@ types:
           type: object
           properties:
             detail:
+              description: Error detail
               type: string
 
 /valid:


### PR DESCRIPTION
## Summary
- Adds a new `ErrorResponseStructureRule` that validates error response body types (HTTP 4xx/5xx) follow the API Design Guidelines structure
- Error response body types **must** have `statusCode` and `message` properties
- Error response body types **should** have an `errors` array property (WARN severity)
- Error items in the `errors` array **must** have `code` and `message` properties
- Supports exclusions by endpoint (`METHOD /path`)

## Potential Violations
- Estimated **2 APIs with violations** out of 8 total API specs:
  - **Frontend API** (`Error` type): missing `statusCode` property, missing `errors` array
  - **MIST API** (`ErrorResponse` type): uses `httpStatus` instead of `statusCode`, uses `validationErrors: string[]` instead of `errors: ErrorObject[]`
- **6 APIs fully compliant**: API (Composable Commerce), History, Import, Checkout, Connect, Insights

> **Note:** These violations will need to be added as exceptions to this rule in the respective `ruleset.xml` files. This will be done later in the docs release after the rmf-codegen release.

## Test plan
- [x] `./gradlew :ctp-validators:test` passes
- [x] Rule correctly validates error response body structure (statusCode, message, errors array, error item code/message)
- [x] WARN severity for missing `errors` array (SHOULD-level guideline)
- [x] ERROR severity for missing `statusCode`, `message`, `code`, `message` (MUST-level guidelines)
- [x] Exclusions work correctly
- [x] Success responses (2xx) are correctly ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)