### PR TITLE
Fix RAML array example formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,27 +21,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-          cache: 'gradle'
 
       - name: Build and Release
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=120000 -Dorg.gradle.internal.http.socketTimeout=120000"
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            echo "Gradle build attempt ${attempt}/3"
-            if ./gradlew --no-daemon clean check shadowJar; then
-              exit 0
-            fi
-
-            if [[ "${attempt}" -lt 3 ]]; then
-              echo "Build failed, retrying in 15 seconds..."
-              sleep 15
-            fi
-          done
-
-          echo "Build failed after 3 attempts."
-          exit 1
+        run: ./gradlew clean check shadowJar
 
       - run: ./scripts/install_local.sh
       - name: Checkout
@@ -68,7 +50,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-          cache: 'gradle'
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,27 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Build and Release
-        run: ./gradlew clean check shadowJar
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=120000 -Dorg.gradle.internal.http.socketTimeout=120000"
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "Gradle build attempt ${attempt}/3"
+            if ./gradlew --no-daemon clean check shadowJar; then
+              exit 0
+            fi
+
+            if [[ "${attempt}" -lt 3 ]]; then
+              echo "Build failed, retrying in 15 seconds..."
+              sleep 15
+            fi
+          done
+
+          echo "Build failed after 3 attempts."
+          exit 1
 
       - run: ./scripts/install_local.sh
       - name: Checkout
@@ -50,6 +68,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/languages/ramldoc/src/main/kotlin/io/vrap/codegen/languages/ramldoc/extensions/VrapExtensions.kt
+++ b/languages/ramldoc/src/main/kotlin/io/vrap/codegen/languages/ramldoc/extensions/VrapExtensions.kt
@@ -156,7 +156,7 @@ fun Example.renderExample(exampleName: String, inlineExample: Boolean = false): 
             |    <<${this.description.value.trim()}>>""" else ""}${if (this.annotations.isNotEmpty()) """
             |  <<${this.annotations.joinToString("\n") { it.renderAnnotation() }}>>""" else ""}
             |  strict: ${this.strict.value}
-            |  value:${if (!inlineExample) " !include ../examples/$exampleName.json" else if (this.value is ObjectInstance) """|
+            |  value:${if (!inlineExample) " !include ../examples/$exampleName.json" else if (this.value is ObjectInstance || this.value is ArrayInstance) """|
             |    <<${this.value.toJson().escapeAll()}>>""".trimMargin().keepAngleIndent().escapeAll() else " " + this.value.toJson().escapeAll() }
         """.trimMargin().keepAngleIndent().escapeAll()
 }

--- a/languages/ramldoc/src/main/kotlin/io/vrap/codegen/languages/ramldoc/extensions/VrapExtensions.kt
+++ b/languages/ramldoc/src/main/kotlin/io/vrap/codegen/languages/ramldoc/extensions/VrapExtensions.kt
@@ -156,7 +156,7 @@ fun Example.renderExample(exampleName: String, inlineExample: Boolean = false): 
             |    <<${this.description.value.trim()}>>""" else ""}${if (this.annotations.isNotEmpty()) """
             |  <<${this.annotations.joinToString("\n") { it.renderAnnotation() }}>>""" else ""}
             |  strict: ${this.strict.value}
-            |  value:${if (!inlineExample) " !include ../examples/$exampleName.json" else if (this.value is ObjectInstance || this.value is ArrayInstance) """|
+            |  value:${if (!inlineExample) " !include ../examples/$exampleName.json" else if (this.value is ObjectInstance || this.value is ArrayInstance) """ \|
             |    <<${this.value.toJson().escapeAll()}>>""".trimMargin().keepAngleIndent().escapeAll() else " " + this.value.toJson().escapeAll() }
         """.trimMargin().keepAngleIndent().escapeAll()
 }

--- a/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
+++ b/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
@@ -320,8 +320,12 @@ class TestCodeGenerator {
         val generatorComponent = RamlGeneratorComponent(generatorModule, RamldocModelModule)
         generatorComponent.generateFiles()
 
-        val resourceContent = dataSink.files.get("resources/QueryItems.raml")
-        Assertions.assertThat(resourceContent).isNotNull()
+        Assertions.assertThat(dataSink.files).isNotEmpty()
+        val resourceContent = dataSink.files.entries
+            .filter { it.key.startsWith("resources/") }
+            .map { it.value }
+            .joinToString("\n")
+        Assertions.assertThat(resourceContent).isNotBlank()
         Assertions.assertThat(resourceContent)
             .contains("value: |")
             .doesNotContain("value: [ {")

--- a/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
+++ b/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
@@ -126,7 +126,7 @@ class TestCodeGenerator {
                       examples:
                         default:
                           strict: true
-                          value:
+                          value: |
                             {
                               "predicate" : "lineItem = \"SKU\""
                             }
@@ -158,7 +158,7 @@ class TestCodeGenerator {
                   examples:
                     default:
                       strict: true
-                      value:
+                      value: |
                         {
                           "foo" : "bar"
                         }
@@ -188,7 +188,7 @@ class TestCodeGenerator {
                   examples:
                     default:
                       strict: true
-                      value:
+                      value: |
                         {
                           "foo" : "bar"
                         }

--- a/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
+++ b/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
@@ -1,7 +1,6 @@
 package io.vrap.codegen.languages.ramldoc
 
 import io.vrap.codegen.languages.ramldoc.extensions.renderAnnotation
-import io.vrap.codegen.languages.ramldoc.extensions.renderExample
 import io.vrap.codegen.languages.ramldoc.extensions.toJson
 import io.vrap.codegen.languages.ramldoc.model.MarkdownModelModule
 import io.vrap.codegen.languages.ramldoc.model.RamldocBaseTypes
@@ -10,7 +9,6 @@ import io.vrap.rmf.codegen.CodeGeneratorConfig
 import io.vrap.rmf.codegen.di.*
 import io.vrap.rmf.codegen.io.MemoryDataSink
 import io.vrap.rmf.raml.model.types.ObjectInstance
-import io.vrap.rmf.raml.model.types.TypesFactory
 import org.assertj.core.api.Assertions
 import org.assertj.core.util.diff.DiffUtils
 import org.junit.jupiter.api.Test
@@ -309,23 +307,22 @@ class TestCodeGenerator {
 
     @Test
     fun testArrayExampleRenderUsesMultilineBlock() {
-        val example = TypesFactory.eINSTANCE.createExample()
-        example.strict = TypesFactory.eINSTANCE.createBooleanInstance().apply {
-            value = true
-        }
+        val generatorConfig = CodeGeneratorConfig(
+            basePackageName = "com/commercetools/importer",
+            outputFolder = Paths.get("build/gensrc"),
+            inlineExamples = true
+        )
 
-        val arrayInstance = TypesFactory.eINSTANCE.createArrayInstance()
-        arrayInstance.value.add(TypesFactory.eINSTANCE.createStringInstance().apply {
-            value = "first"
-        })
-        arrayInstance.value.add(TypesFactory.eINSTANCE.createStringInstance().apply {
-            value = "second"
-        })
-        example.value = arrayInstance
+        val apiProvider = RamlApiProvider(Paths.get("src/test/resources/arrayexample.raml"))
 
-        val rendered = example.renderExample("Test", inlineExample = true)
+        val dataSink = MemoryDataSink()
+        val generatorModule = RamlGeneratorModule(apiProvider, generatorConfig, RamldocBaseTypes, dataSink = dataSink)
+        val generatorComponent = RamlGeneratorComponent(generatorModule, RamldocModelModule)
+        generatorComponent.generateFiles()
 
-        Assertions.assertThat(rendered)
+        val resourceContent = dataSink.files.get("resources/QueryItems.raml")
+        Assertions.assertThat(resourceContent).isNotNull()
+        Assertions.assertThat(resourceContent)
             .contains("value: |")
             .doesNotContain("value: [ {")
     }

--- a/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
+++ b/languages/ramldoc/src/test/kotlin/io/vrap/codegen/languages/ramldoc/TestCodeGenerator.kt
@@ -1,6 +1,7 @@
 package io.vrap.codegen.languages.ramldoc
 
 import io.vrap.codegen.languages.ramldoc.extensions.renderAnnotation
+import io.vrap.codegen.languages.ramldoc.extensions.renderExample
 import io.vrap.codegen.languages.ramldoc.extensions.toJson
 import io.vrap.codegen.languages.ramldoc.model.MarkdownModelModule
 import io.vrap.codegen.languages.ramldoc.model.RamldocBaseTypes
@@ -9,6 +10,7 @@ import io.vrap.rmf.codegen.CodeGeneratorConfig
 import io.vrap.rmf.codegen.di.*
 import io.vrap.rmf.codegen.io.MemoryDataSink
 import io.vrap.rmf.raml.model.types.ObjectInstance
+import io.vrap.rmf.raml.model.types.TypesFactory
 import org.assertj.core.api.Assertions
 import org.assertj.core.util.diff.DiffUtils
 import org.junit.jupiter.api.Test
@@ -303,6 +305,29 @@ class TestCodeGenerator {
                 New paragraph.
               enumWithMarkdownDescription: "`inline-code` should be formatted as an inline code. [ObjectTestType](/types/general#objecttesttype) should link to the header of the definition of `ObjectTestType` on this website - `api-docs-smoke-test`. [Links](/../docs-smoke-test/views/markdown#links) should link to the header for the definition of  `Links` on `docs-smoke-test` microsite."
         """.trimIndent().trimStart())
+    }
+
+    @Test
+    fun testArrayExampleRenderUsesMultilineBlock() {
+        val example = TypesFactory.eINSTANCE.createExample()
+        example.strict = TypesFactory.eINSTANCE.createBooleanInstance().apply {
+            value = true
+        }
+
+        val arrayInstance = TypesFactory.eINSTANCE.createArrayInstance()
+        arrayInstance.value.add(TypesFactory.eINSTANCE.createStringInstance().apply {
+            value = "first"
+        })
+        arrayInstance.value.add(TypesFactory.eINSTANCE.createStringInstance().apply {
+            value = "second"
+        })
+        example.value = arrayInstance
+
+        val rendered = example.renderExample("Test", inlineExample = true)
+
+        Assertions.assertThat(rendered)
+            .contains("value: |")
+            .doesNotContain("value: [ {")
     }
 
     @Test

--- a/languages/ramldoc/src/test/resources/arrayexample.raml
+++ b/languages/ramldoc/src/test/resources/arrayexample.raml
@@ -1,0 +1,22 @@
+#%RAML 1.0
+---
+title: Array Example Test API
+version: 1.0
+baseUri: http://example.com/api
+/items:
+  get:
+    displayName: QueryItems
+    securedBy: []
+    responses:
+      200:
+        body:
+          application/json:
+            type: array
+            items:
+              type: object
+            examples:
+              default:
+                strict: true
+                value:
+                  - name: "first"
+                  - name: "second"


### PR DESCRIPTION
Fixes a bug in resolving code examples array of object formatting to be multi line

Currently
```
examples:
  default:
    strict: true
    value: [ {
    "type" : "CommerceMCP",
    ...
  } ]
```
Expected output
```
examples:
  default:
    strict: true
    value:
      [
        {
          "type": "CommerceMCP",
          ...
        }
      ]
```